### PR TITLE
유저 데이터 유효성 체크

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, ValidationPipe } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthCredentialsDto } from './dto/auth-credential.dto';
 
@@ -7,7 +7,9 @@ export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post('/signup')
-  signUp(@Body() authcredentialsDto: AuthCredentialsDto): Promise<void> {
+  signUp(
+    @Body(ValidationPipe) authcredentialsDto: AuthCredentialsDto,
+  ): Promise<void> {
     return this.authService.signUp(authcredentialsDto);
   }
 }

--- a/src/auth/dto/auth-credential.dto.ts
+++ b/src/auth/dto/auth-credential.dto.ts
@@ -1,4 +1,16 @@
+import { IsString, Matches, MaxLength, MinLength } from 'class-validator';
+
 export class AuthCredentialsDto {
+  @IsString()
+  @MinLength(4)
+  @MaxLength(20)
   username: string;
+
+  @IsString()
+  @MinLength(4)
+  @MaxLength(20)
+  @Matches(/^[a-zA-Z0-9]*$/, {
+    message: 'password only accepts english and number',
+  })
   password: string;
 }


### PR DESCRIPTION
* 회원가입시 유저 데이터의 유효성을 체크한다.
* username/password 모두 4-20자의 영어 혹은 숫자로 구성되어야한다. 
* 어긋날시 에러메세지 반환